### PR TITLE
feat: add DynamicFieldsSerializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,8 @@ celerybeat-schedule
 # Environments
 .env
 .venv
+Pipfile
+Pipfile.lock
 env/
 venv/
 ENV/

--- a/aether/sdk/drf/serializers.py
+++ b/aether/sdk/drf/serializers.py
@@ -87,19 +87,18 @@ class FilteredHyperlinkedRelatedField(HyperlinkedRelatedField):
 
 
 # https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
-class DynamicFieldsSerializer(serializers.Serializer):
+class DynamicFieldsSerializerMixin(object):
     '''
-    A Serializer that takes two additional arguments ``fields`` and ``omit``
+    Add addtional functionality to Serializers adding two arguments ``fields`` and ``omit``
     that control which fields should be displayed.
     '''
-
     def __init__(self, *args, **kwargs):
         # Don't pass the custom arguments up to the superclass
         fields = kwargs.pop('fields', None)
         omit = kwargs.pop('omit', None)
 
         # Instantiate the superclass normally
-        super(DynamicFieldsSerializer, self).__init__(*args, **kwargs)
+        super(DynamicFieldsSerializerMixin, self).__init__(*args, **kwargs)
 
         if fields:
             # Drop any fields that are not specified in the ``fields`` argument.
@@ -115,33 +114,12 @@ class DynamicFieldsSerializer(serializers.Serializer):
                 self.fields.pop(field_name, None)
 
 
-# https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
-class DynamicFieldsModelSerializer(serializers.ModelSerializer):
-    '''
-    A ModelSerializer that takes two additional arguments ``fields`` and ``omit``
-    that control which fields should be displayed.
-    '''
+class DynamicFieldsSerializer(DynamicFieldsSerializerMixin, serializers.Serializer):
+    pass
 
-    def __init__(self, *args, **kwargs):
-        # Don't pass the custom arguments up to the superclass
-        fields = kwargs.pop('fields', None)
-        omit = kwargs.pop('omit', None)
 
-        # Instantiate the superclass normally
-        super(DynamicFieldsModelSerializer, self).__init__(*args, **kwargs)
-
-        if fields:
-            # Drop any fields that are not specified in the ``fields`` argument.
-            allowed = set(fields)
-            existing = set(self.fields)
-            for field_name in existing - allowed:
-                self.fields.pop(field_name)
-
-        if omit:
-            # Drop any fields that are specified in the ``omit`` argument.
-            not_allowed = set(omit)
-            for field_name in not_allowed:
-                self.fields.pop(field_name, None)
+class DynamicFieldsModelSerializer(DynamicFieldsSerializerMixin, serializers.ModelSerializer):
+    pass
 
 
 class UsernameField(serializers.Field):

--- a/aether/sdk/drf/serializers.py
+++ b/aether/sdk/drf/serializers.py
@@ -89,7 +89,7 @@ class FilteredHyperlinkedRelatedField(HyperlinkedRelatedField):
 # https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
 class DynamicFieldsSerializerMixin(object):
     '''
-    Add addtional functionality to Serializers adding two arguments ``fields`` and ``omit``
+    Add additional functionality to Serializers adding two arguments ``fields`` and ``omit``
     that control which fields should be displayed.
     '''
     def __init__(self, *args, **kwargs):

--- a/aether/sdk/drf/serializers.py
+++ b/aether/sdk/drf/serializers.py
@@ -87,6 +87,35 @@ class FilteredHyperlinkedRelatedField(HyperlinkedRelatedField):
 
 
 # https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
+class DynamicFieldsSerializer(serializers.Serializer):
+    '''
+    A Serializer that takes two additional arguments ``fields`` and ``omit``
+    that control which fields should be displayed.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        # Don't pass the custom arguments up to the superclass
+        fields = kwargs.pop('fields', None)
+        omit = kwargs.pop('omit', None)
+
+        # Instantiate the superclass normally
+        super(DynamicFieldsSerializer, self).__init__(*args, **kwargs)
+
+        if fields:
+            # Drop any fields that are not specified in the ``fields`` argument.
+            allowed = set(fields)
+            existing = set(self.fields)
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)
+
+        if omit:
+            # Drop any fields that are specified in the ``omit`` argument.
+            not_allowed = set(omit)
+            for field_name in not_allowed:
+                self.fields.pop(field_name, None)
+
+
+# https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):
     '''
     A ModelSerializer that takes two additional arguments ``fields`` and ``omit``

--- a/aether/sdk/drf/tests/test_serializers.py
+++ b/aether/sdk/drf/tests/test_serializers.py
@@ -21,7 +21,9 @@ from django.contrib.auth import get_user_model
 from django.test import RequestFactory, override_settings
 
 from aether.sdk.tests import AetherTestCase
-from aether.sdk.tests.fakeapp.serializers import TestUserSerializer, TestUserSerializer2
+from aether.sdk.tests.fakeapp.serializers import (
+    TestUserSerializer, TestUserSerializer2, TestUserSerializer3
+)
 
 TEST_REALM = 'realm-test'
 
@@ -152,3 +154,23 @@ class SerializersTests(AetherTestCase):
         user.save()
 
         self.assertEqual(user.data['name'], 'John Doe')
+
+    @override_settings(MULTITENANCY=False)
+    def test_base_serializer__no_multitenancy(self):
+        user_data = {
+            'id': 408,
+            'username': 'user',
+            'first_name': 'John',
+            'last_name': 'Doe',
+        }
+
+        user = TestUserSerializer3(
+            data=user_data,
+            context={'request': self.request},
+            omit=['last_name']
+        )
+        self.assertTrue(user.is_valid(), user.errors)
+        user.save()
+
+        self.assertEqual(user.data['id'], user_data['id'])
+        self.assertFalse('last_name' in user.data.keys())

--- a/aether/sdk/drf/views.py
+++ b/aether/sdk/drf/views.py
@@ -18,6 +18,7 @@
 
 from django.conf import settings
 from django.db import transaction
+from django.utils.translation import gettext as _
 
 from rest_framework import status
 from rest_framework.decorators import action
@@ -116,6 +117,6 @@ class FilteredMixin(CacheViewSetMixin):
                 )
         else:
             return Response(
-                ('No values to update'),
+                _('No values to update'),
                 status=status.HTTP_400_BAD_REQUEST
             )

--- a/aether/sdk/drf/views.py
+++ b/aether/sdk/drf/views.py
@@ -18,7 +18,6 @@
 
 from django.conf import settings
 from django.db import transaction
-from django.utils.translation import gettext as _
 
 from rest_framework import status
 from rest_framework.decorators import action
@@ -117,6 +116,6 @@ class FilteredMixin(CacheViewSetMixin):
                 )
         else:
             return Response(
-                    _('No values to update'),
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+                ('No values to update'),
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/aether/sdk/tests/fakeapp/serializers.py
+++ b/aether/sdk/tests/fakeapp/serializers.py
@@ -17,8 +17,10 @@
 # under the License.
 
 from django.contrib.auth import get_user_model
+from rest_framework import serializers
 
 from aether.sdk.drf.serializers import (
+    DynamicFieldsSerializer,
     DynamicFieldsModelSerializer,
     FilteredHyperlinkedRelatedField,
     HyperlinkedIdentityField,
@@ -100,3 +102,14 @@ class TestUserSerializer2(DynamicFieldsModelSerializer):
             # required to test UserNameField
             'name', 'first_name', 'last_name',
         )
+
+
+class TestUserSerializer3(DynamicFieldsSerializer):
+
+    id = serializers.IntegerField()
+    username = serializers.CharField()
+    first_name = serializers.CharField()
+    last_name = serializers.CharField()
+
+    def create(self, validated_data):
+        return UserModel(**validated_data)


### PR DESCRIPTION
ModelSerializer is slow in Django 2.x due to a bug in `lazy` The base serializer is more performant, but required more boilerplate. This adds a DynamicFieldsSerializer based on Serializer which can be swapped in for DynamicFieldsModelSerializer with a little work.